### PR TITLE
Make Attributes Bytes32

### DIFF
--- a/contracts/DefaultRegistryAccessManager.sol
+++ b/contracts/DefaultRegistryAccessManager.sol
@@ -7,25 +7,13 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 contract DefaultRegistryAccessManager is RegistryAccessManager {
     using SafeMath for uint256;
 
-    string public constant WRITE_PERMISSION = "canWriteTo-";
+    bytes32 public constant WRITE_PERMISSION = keccak("canWriteTo-");
 
     // Allows a write if either a) the writer is that Registry's owner, or
     // b) the writer is writing to attribute foo and that writer already has
     // the canWriteTo-foo attribute set (in that same Registry)
-    function confirmWrite(address /*_who*/, string _attribute, uint256 /*_value*/, bytes32 /*_notes*/, address _admin) public returns (bool) {
+    function confirmWrite(address /*_who*/, bytes32 _attribute, uint256 /*_value*/, bytes32 /*_notes*/, address _admin) public returns (bool) {
         Registry client = Registry(msg.sender);
-        return (_admin == client.owner() || client.hasAttribute(_admin, strConcat(WRITE_PERMISSION, _attribute)));
-    }
-
-    // Based on https://github.com/oraclize/ethereum-api/blob/master/oraclizeAPI_0.5.sol#L830
-    function strConcat(string _x, string _y) internal pure returns (string) {
-        bytes memory bx = bytes(_x);
-        bytes memory by = bytes(_y);
-        string memory xy = new string(bx.length.add(by.length));
-        bytes memory bxy = bytes(xy);
-        uint k = 0;
-        for (uint i = 0; i < bx.length; i++) bxy[k++] = bx[i];
-        for (i = 0; i < by.length; i++) bxy[k++] = by[i];
-        return string(bxy);
+        return (_admin == client.owner() || client.hasAttribute(_admin, WRITE_PERMISSION ^ _attribute));
     }
 }

--- a/contracts/DefaultRegistryAccessManager.sol
+++ b/contracts/DefaultRegistryAccessManager.sol
@@ -7,7 +7,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 contract DefaultRegistryAccessManager is RegistryAccessManager {
     using SafeMath for uint256;
 
-    bytes32 public constant WRITE_PERMISSION = keccak("canWriteTo-");
+    bytes32 public constant WRITE_PERMISSION = keccak256("canWriteTo-");
 
     // Allows a write if either a) the writer is that Registry's owner, or
     // b) the writer is writing to attribute foo and that writer already has

--- a/contracts/DefaultRegistryAccessManager.sol
+++ b/contracts/DefaultRegistryAccessManager.sol
@@ -14,6 +14,6 @@ contract DefaultRegistryAccessManager is RegistryAccessManager {
     // the canWriteTo-foo attribute set (in that same Registry)
     function confirmWrite(address /*_who*/, bytes32 _attribute, uint256 /*_value*/, bytes32 /*_notes*/, address _admin) public returns (bool) {
         Registry client = Registry(msg.sender);
-        return (_admin == client.owner() || client.hasAttribute(_admin, WRITE_PERMISSION ^ _attribute));
+        return (_admin == client.owner() || client.hasAttribute(_admin, keccak256(WRITE_PERMISSION ^ _attribute)));
     }
 }

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -31,11 +31,16 @@ contract Registry is Claimable {
     event SetManager(address indexed oldManager, address indexed newManager);
 
 
+    function writeAttributeFor(bytes32 _attribute)
+    public pure returns (bytes32) {
+        return keccak256(WRITE_PERMISSION ^ _attribute);
+    }
+
     // Allows a write if either a) the writer is that Registry's owner, or
     // b) the writer is writing to attribute foo and that writer already has
     // the canWriteTo-foo attribute set (in that same Registry)
     function confirmWrite(address /*_who*/, bytes32 _attribute, uint256 /*_value*/, bytes32 /*_notes*/, address _admin) public returns (bool) {
-        return (_admin == owner || hasAttribute(_admin, WRITE_PERMISSION ^ _attribute));
+        return (_admin == owner || hasAttribute(_admin, keccak256(WRITE_PERMISSION ^ _attribute)));
     }
 
     // Writes are allowed only if the accessManager approves

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -19,7 +19,7 @@ contract Registry is Claimable {
     // that account can use the token. This mapping stores that value (1, in the
     // example) as well as which validator last set the value and at what time,
     // so that e.g. the check can be renewed at appropriate intervals.
-    mapping(address => mapping(string => AttributeData)) private attributes;
+    mapping(address => mapping(bytes32 => AttributeData)) private attributes;
     // The logic governing who is allowed to set what attributes is abstracted as
     // this accessManager, so that it may be replaced by the owner as needed
     RegistryAccessManager public accessManager;
@@ -28,27 +28,27 @@ contract Registry is Claimable {
         accessManager = new DefaultRegistryAccessManager();
     }
 
-    event SetAttribute(address indexed who, string attribute, uint256 value, bytes32 notes, address indexed adminAddr);
+    event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
     event SetManager(address indexed oldManager, address indexed newManager);
 
     // Writes are allowed only if the accessManager approves
-    function setAttribute(address _who, string _attribute, uint256 _value, bytes32 _notes) public {
+    function setAttribute(address _who, bytes32 _attribute, uint256 _value, bytes32 _notes) public {
         require(accessManager.confirmWrite(_who, _attribute, _value, _notes, msg.sender));
         attributes[_who][_attribute] = AttributeData(_value, _notes, msg.sender, block.timestamp);
         emit SetAttribute(_who, _attribute, _value, _notes, msg.sender);
     }
 
     // Returns true if the uint256 value stored for this attribute is non-zero
-    function hasAttribute(address _who, string _attribute) public view returns (bool) {
+    function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
         return attributes[_who][_attribute].value != 0;
     }
 
-    function getAttributeValue(address _who, string _attribute) public view returns (uint256 _value) {
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256 _value) {
         _value = attributes[_who][_attribute].value;
     }
 
     // Returns the exact value of the attribute, as well as its metadata
-    function getAttribute(address _who, string _attribute) public view returns (uint256, bytes32, address, uint256) {
+    function getAttribute(address _who, bytes32 _attribute) public view returns (uint256, bytes32, address, uint256) {
         AttributeData memory data = attributes[_who][_attribute];
         return (data.value, data.notes, data.adminAddr, data.timestamp);
     }

--- a/contracts/RegistryAccessManager.sol
+++ b/contracts/RegistryAccessManager.sol
@@ -6,5 +6,5 @@ import "./Registry.sol";
 contract RegistryAccessManager {
     // Called when _admin attempts to write _value for _who's _attribute.
     // Returns true if the write is allowed to proceed.
-    function confirmWrite(address _who, string _attribute, uint256 _value, bytes32 _notes, address _admin) public returns (bool);
+    function confirmWrite(address _who, bytes32 _attribute, uint256 _value, bytes32 _notes, address _admin) public returns (bool);
 }

--- a/contracts/mocks/RegistryAccessManagerMock.sol
+++ b/contracts/mocks/RegistryAccessManagerMock.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.23;
 import "../RegistryAccessManager.sol";
 
 contract RegistryAccessManagerMock is RegistryAccessManager {
-    function confirmWrite(address _who, string _attribute, uint256 _value, bytes32 _notes, address _admin) public returns (bool) {
+    function confirmWrite(address _who, bytes32 _attribute, uint256 _value, bytes32 _notes, address _admin) public returns (bool) {
         return true;
     }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "babel-preset-stage-2": "^6.18.0",
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.26.0",
+    "bn.js": "^4.11.8",
     "ganache-cli": "6.1.0",
     "openzeppelin-solidity": "^1.9.0",
     "solidity-coverage": "^0.5.0",

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -3,12 +3,14 @@ const Registry = artifacts.require('Registry')
 const RegistryAccessManagerMock = artifacts.require('RegistryAccessManagerMock')
 const MockToken = artifacts.require("MockToken")
 const ForceEther = artifacts.require("ForceEther")
+const BN = require('bn.js')
 
 contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
-    const prop1 = web3.sha3("foo")
     const prop2 = "bar"
     const notes = "blarg"
-    const canWriteProp1 = "0xb6e46a64b8cca9f5f4dcd34ff27fac5267998e4bde07acc0f7e58fcb9562959e"
+    const prop1 = web3.sha3("foo")
+    var prop1BN = new BN(prop1);
+    const canWriteProp1 = web3.sha3(prop1BN.xor(new BN(web3.sha3("canWriteTo-"))).toString(16))
 
     beforeEach(async function () {
         this.registry = await Registry.new({ from: owner })

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -5,10 +5,10 @@ const MockToken = artifacts.require("MockToken")
 const ForceEther = artifacts.require("ForceEther")
 
 contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
-    const prop1 = "foo"
+    const prop1 = web3.sha3("foo")
     const prop2 = "bar"
     const notes = "blarg"
-    const writePermissionTag = "canWriteTo-"
+    const canWriteProp1 = "0xb6e46a64b8cca9f5f4dcd34ff27fac5267998e4bde07acc0f7e58fcb9562959e"
 
     beforeEach(async function () {
         this.registry = await Registry.new({ from: owner })
@@ -55,12 +55,12 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
         })
 
         it('owner can let others write', async function () {
-            await this.registry.setAttribute(oneHundred, writePermissionTag+prop1, 3, notes, { from: owner })
+            await this.registry.setAttribute(oneHundred, canWriteProp1, 3, notes, { from: owner })
             await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: oneHundred })
         })
 
         it('others can only write what they are allowed to', async function () {
-            await this.registry.setAttribute(oneHundred, writePermissionTag+prop1, 3, notes, { from: owner })
+            await this.registry.setAttribute(oneHundred, canWriteProp1, 3, notes, { from: owner })
             await assertRevert(this.registry.setAttribute(anotherAccount, prop2, 3, notes, { from: oneHundred }))
         })
     })


### PR DESCRIPTION

#### Changes
This changes the keys for attributes to be a fixed-size word.
Clients can still remember string keys, but they would pass a constant hash of that string instead.
This slightly reduces calldata size because the string length does not have to be passed.
Reviewers @terryli0095