### PR TITLE
rm initialization

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -10,9 +10,10 @@ contract Registry {
         uint256 timestamp;
     }
     
+    // never remove any storage variables
     address public owner;
     address public pendingOwner;
-    bool public initialized;
+    bool private initialized;
 
     // Stores arbitrary attributes for users. An example use case is an ERC20
     // token that requires its users to go through a KYC/AML check - in this case
@@ -35,13 +36,6 @@ contract Registry {
     );
     event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
     event SetManager(address indexed oldManager, address indexed newManager);
-
-
-    function initialize() public {
-        require(!initialized, "already initialized");
-        owner = msg.sender;
-        initialized = true;
-    }
 
     function writeAttributeFor(bytes32 _attribute) public pure returns (bytes32) {
         return keccak256(WRITE_PERMISSION ^ _attribute);

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -145,15 +145,6 @@ contract Registry {
     }
 
     /**
-    * @dev sets the original `owner` of the contract to the sender
-    * at construction. Must then be reinitialized 
-    */
-    constructor() public {
-        owner = msg.sender;
-        emit OwnershipTransferred(address(0), owner);
-    }
-
-    /**
     * @dev Throws if called by any account other than the owner.
     */
     modifier onlyOwner() {

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -13,7 +13,7 @@ contract Registry {
     // never remove any storage variables
     address public owner;
     address public pendingOwner;
-    bool private initialized;
+    bool initialized;
 
     // Stores arbitrary attributes for users. An example use case is an ERC20
     // token that requires its users to go through a KYC/AML check - in this case

--- a/contracts/mocks/RegistryMock.sol
+++ b/contracts/mocks/RegistryMock.sol
@@ -3,6 +3,15 @@ import "../Registry.sol";
 
 contract RegistryMock is Registry {
 
+    /**
+    * @dev sets the original `owner` of the contract to the sender
+    * at construction. Must then be reinitialized
+    */
+    constructor() public {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), owner);
+    }
+
     function initialize() public {
         require(!initialized, "already initialized");
         owner = msg.sender;

--- a/contracts/mocks/RegistryMock.sol
+++ b/contracts/mocks/RegistryMock.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.4.23;
+import "../Registry.sol";
+
+contract RegistryMock is Registry {
+
+    function initialize() public {
+        require(!initialized, "already initialized");
+        owner = msg.sender;
+        initialized = true;
+    }
+
+}

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -1,5 +1,5 @@
 import assertRevert from './helpers/assertRevert'
-const Registry = artifacts.require('Registry')
+const RegistryMock = artifacts.require('RegistryMock')
 const MockToken = artifacts.require("MockToken")
 const ForceEther = artifacts.require("ForceEther")
 const BN = require('bn.js')
@@ -13,7 +13,7 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
     const notes = "blarg"
     
     beforeEach(async function () {
-        this.registry = await Registry.new({ from: owner })
+        this.registry = await RegistryMock.new({ from: owner })
         await this.registry.initialize({ from: owner })
     })
 

--- a/truffle.js
+++ b/truffle.js
@@ -7,7 +7,7 @@ module.exports = {
   solc: {
     optimizer: {
       enabled: true,
-      runs: 2000000000
+      runs: 200
     }
   },
   networks: {


### PR DESCRIPTION

#### Changes
This removes the initalization code, including the initialized getter, moving it to the mock.
Reviewers @terryli0095