### PR TITLE
Truffle 5 and remove view methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ allFiredEvents
 coverage
 coverage.json
 coverageEnv
+
+# VIM
+*.swp

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -39,10 +39,6 @@ contract Registry {
     event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
     event SetManager(address indexed oldManager, address indexed newManager);
 
-    function writeAttributeFor(bytes32 _attribute) internal pure returns (bytes32) {
-        return keccak256(WRITE_PERMISSION ^ _attribute);
-    }
-
     // Allows a write if either a) the writer is that Registry's owner, or
     // b) the writer is writing to attribute foo and that writer already has
     // the canWriteTo-foo attribute set (in that same Registry)

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -21,16 +21,16 @@ contract Registry {
     // that account can use the token. This mapping stores that value (1, in the
     // example) as well as which validator last set the value and at what time,
     // so that e.g. the check can be renewed at appropriate intervals.
-    mapping(address => mapping(bytes32 => AttributeData)) public attributes;
+    mapping(address => mapping(bytes32 => AttributeData)) attributes;
     // The logic governing who is allowed to set what attributes is abstracted as
     // this accessManager, so that it may be replaced by the owner as needed
 
-    bytes32 public constant WRITE_PERMISSION = keccak256("canWriteTo-");
-    bytes32 public constant IS_BLACKLISTED = "isBlacklisted";
-    bytes32 public constant IS_DEPOSIT_ADDRESS = "isDepositAddress"; 
-    bytes32 public constant IS_REGISTERED_CONTRACT = "isRegisteredContract"; 
-    bytes32 public constant HAS_PASSED_KYC_AML = "hasPassedKYC/AML";
-    bytes32 public constant CAN_BURN = "canBurn";
+    bytes32 constant WRITE_PERMISSION = keccak256("canWriteTo-");
+    bytes32 constant IS_BLACKLISTED = "isBlacklisted";
+    bytes32 constant IS_DEPOSIT_ADDRESS = "isDepositAddress";
+    bytes32 constant IS_REGISTERED_CONTRACT = "isRegisteredContract";
+    bytes32 constant HAS_PASSED_KYC_AML = "hasPassedKYC/AML";
+    bytes32 constant CAN_BURN = "canBurn";
 
     event OwnershipTransferred(
         address indexed previousOwner,
@@ -39,14 +39,14 @@ contract Registry {
     event SetAttribute(address indexed who, bytes32 attribute, uint256 value, bytes32 notes, address indexed adminAddr);
     event SetManager(address indexed oldManager, address indexed newManager);
 
-    function writeAttributeFor(bytes32 _attribute) public pure returns (bytes32) {
+    function writeAttributeFor(bytes32 _attribute) internal pure returns (bytes32) {
         return keccak256(WRITE_PERMISSION ^ _attribute);
     }
 
     // Allows a write if either a) the writer is that Registry's owner, or
     // b) the writer is writing to attribute foo and that writer already has
     // the canWriteTo-foo attribute set (in that same Registry)
-    function confirmWrite(bytes32 _attribute, address _admin) public view returns (bool) {
+    function confirmWrite(bytes32 _attribute, address _admin) internal view returns (bool) {
         return (_admin == owner || hasAttribute(_admin, keccak256(WRITE_PERMISSION ^ _attribute)));
     }
 
@@ -66,42 +66,6 @@ contract Registry {
     // Returns true if the uint256 value stored for this attribute is non-zero
     function hasAttribute(address _who, bytes32 _attribute) public view returns (bool) {
         return attributes[_who][_attribute].value != 0;
-    }
-
-    function hasBothAttributes(address _who, bytes32 _attribute1, bytes32 _attribute2) public view returns (bool) {
-        return attributes[_who][_attribute1].value != 0 && attributes[_who][_attribute2].value != 0;
-    }
-
-    function hasEitherAttribute(address _who, bytes32 _attribute1, bytes32 _attribute2) public view returns (bool) {
-        return attributes[_who][_attribute1].value != 0 || attributes[_who][_attribute2].value != 0;
-    }
-
-    function hasAttribute1ButNotAttribute2(address _who, bytes32 _attribute1, bytes32 _attribute2) public view returns (bool) {
-        return attributes[_who][_attribute1].value != 0 && attributes[_who][_attribute2].value == 0;
-    }
-
-    function bothHaveAttribute(address _who1, address _who2, bytes32 _attribute) public view returns (bool) {
-        return attributes[_who1][_attribute].value != 0 && attributes[_who2][_attribute].value != 0;
-    }
-    
-    function eitherHaveAttribute(address _who1, address _who2, bytes32 _attribute) public view returns (bool) {
-        return attributes[_who1][_attribute].value != 0 || attributes[_who2][_attribute].value != 0;
-    }
-
-    function haveAttributes(address _who1, bytes32 _attribute1, address _who2, bytes32 _attribute2) public view returns (bool) {
-        return attributes[_who1][_attribute1].value != 0 && attributes[_who2][_attribute2].value != 0;
-    }
-
-    function haveEitherAttribute(address _who1, bytes32 _attribute1, address _who2, bytes32 _attribute2) public view returns (bool) {
-        return attributes[_who1][_attribute1].value != 0 || attributes[_who2][_attribute2].value != 0;
-    }
-
-    function isDepositAddress(address _who) public view returns (bool) {
-        return attributes[address(uint256(_who) >> 20)][IS_DEPOSIT_ADDRESS].value != 0;
-    }
-
-    function getDepositAddress(address _who) public view returns (address) {
-        return address(attributes[address(uint256(_who) >> 20)][IS_DEPOSIT_ADDRESS].value);
     }
 
     function requireCanTransfer(address _from, address _to) public view returns (address, bool) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,11 @@
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
       "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
     },
+    "app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -4841,9 +4846,9 @@
       }
     },
     "openzeppelin-solidity": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.12.0.tgz",
-      "integrity": "sha512-WlorzMXIIurugiSdw121RVD5qA3EfSI7GybTn+/Du0mPNgairjt29NpVTAaH8eLjAeAwlw46y7uQKy0NYem/gA=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.9.0.tgz",
+      "integrity": "sha512-MGI8clDbjrfWUg90AM82O+CHOaabtE2u9HyaUhBMKfWdIaO1urRUIgXIrEuloLvFEBHb5rtcgTARb5DkhUB4KQ=="
     },
     "optimist": {
       "version": "0.6.1",
@@ -6528,13 +6533,34 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "truffle": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.14.tgz",
-      "integrity": "sha512-e7tTLvKP3bN9dE7MagfWyFjy4ZgoEGbeujECy1me1ENBzbj/aO/+45gs72qsL3+3IkCNNcWNOJjjrm8BYZZNNg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.5.tgz",
+      "integrity": "sha512-YKAfHvq3C5hGCc+S+14FNDM8iZPeta9McocKSAkYBxDTiRfyT6yeDrHmSNEU7fzNAc7jFSlwhY7Cs5bXUR3RKg==",
       "requires": {
+        "app-module-path": "^2.2.0",
         "mocha": "^4.1.0",
         "original-require": "1.0.1",
-        "solc": "0.4.24"
+        "solc": "0.5.0"
+      },
+      "dependencies": {
+        "require-from-string": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+          "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+        },
+        "solc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.0.tgz",
+          "integrity": "sha512-mdLHDl9WeYrN+FIKcMc9PlPfnA9DG9ur5QpCDKcv6VC4RINAsTF4EMuXMZMKoQTvZhtLyJIVH/BZ+KU830Z8Xg==",
+          "requires": {
+            "fs-extra": "^0.30.0",
+            "keccak": "^1.0.2",
+            "memorystream": "^0.3.1",
+            "require-from-string": "^2.0.0",
+            "semver": "^5.5.0",
+            "yargs": "^11.0.0"
+          }
+        }
       }
     },
     "truffle-hdwallet-provider": {
@@ -6839,6 +6865,12 @@
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+              "from": "git+https://github.com/debris/bignumber.js.git#master"
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "babel-register": "^6.26.0",
     "bn.js": "^4.11.8",
     "ganache-cli": "6.1.0",
-    "openzeppelin-solidity": "^1.9.0",
+    "openzeppelin-solidity": "1.9.0",
     "solidity-coverage": "^0.5.0",
-    "truffle": "^4.1.8",
+    "truffle": "^5.0.4",
     "truffle-hdwallet-provider": "0.0.3"
   }
 }

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -2,17 +2,19 @@ import assertRevert from './helpers/assertRevert'
 const RegistryMock = artifacts.require('RegistryMock')
 const MockToken = artifacts.require("MockToken")
 const ForceEther = artifacts.require("ForceEther")
-const BN = require('bn.js')
+const BN = web3.utils.toBN;
+const writeAttributeFor = require('./helpers/writeAttributeFor.js')
+const bytes32 = require('./helpers/bytes32.js')
 
 contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
-    const prop1 = web3.sha3("foo")
-    const IS_BLACKLISTED = 'isBlacklisted';
-    const IS_REGISTERED_CONTRACT = 'isRegisteredContract';
-    const IS_DEPOSIT_ADDRESS = 'isDepositAddress';
-    const HAS_PASSED_KYC_AML = "hasPassedKYC/AML";
-    const CAN_BURN = "canBurn";
-    const prop2 = "bar"
-    const notes = "blarg"
+    const prop1 = web3.utils.sha3("foo")
+    const IS_BLACKLISTED = bytes32('isBlacklisted');
+    const IS_REGISTERED_CONTRACT = bytes32('isRegisteredContract');
+    const IS_DEPOSIT_ADDRESS = bytes32('isDepositAddress');
+    const HAS_PASSED_KYC_AML = bytes32("hasPassedKYC/AML");
+    const CAN_BURN = bytes32("canBurn");
+    const prop2 = bytes32("bar")
+    const notes = bytes32("blarg")
     
     beforeEach(async function () {
         this.registry = await RegistryMock.new({ from: owner })
@@ -45,9 +47,9 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
             const { receipt } = await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: owner })
             const attr = await this.registry.getAttribute(anotherAccount, prop1)
             assert.equal(attr[0], 3)
-            assert.equal(web3.toUtf8(attr[1]), notes)
+            assert.equal(attr[1], notes)
             assert.equal(attr[2], owner)
-            assert.equal(attr[3], web3.eth.getBlock(receipt.blockNumber).timestamp)
+            assert.equal(attr[3], (await web3.eth.getBlock(receipt.blockNumber)).timestamp)
             const hasAttr = await this.registry.hasAttribute(anotherAccount, prop1)
             assert.equal(hasAttr, true)
             const value = await this.registry.getAttributeValue(anotherAccount, prop1)
@@ -55,11 +57,11 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
             const adminAddress = await this.registry.getAttributeAdminAddr(anotherAccount, prop1)
             assert.equal(adminAddress, owner)
             const timestamp = await this.registry.getAttributeTimestamp(anotherAccount, prop1)
-            assert.equal(timestamp,web3.eth.getBlock(receipt.blockNumber).timestamp)
+            assert.equal(timestamp, (await web3.eth.getBlock(receipt.blockNumber)).timestamp)
         })
 
         it('sets only desired attribute', async function () {
-            const { receipt } = await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: owner })
+            await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: owner })
             const attr = await this.registry.getAttribute(anotherAccount, prop2)
             assert.equal(attr[0], 0)
             assert.equal(attr[1], '0x0000000000000000000000000000000000000000000000000000000000000000')
@@ -76,7 +78,7 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
             assert.equal(logs[0].args.who, anotherAccount)
             assert.equal(logs[0].args.attribute, prop1)
             assert.equal(logs[0].args.value, 3)
-            assert.equal(web3.toUtf8(logs[0].args.notes), notes)
+            assert.equal(logs[0].args.notes, notes)
             assert.equal(logs[0].args.adminAddr, owner)
         })
 
@@ -85,93 +87,22 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
         })
 
         it('owner can let others write', async function () {
-            const canWriteProp1 = await this.registry.writeAttributeFor(prop1);
+            const canWriteProp1 = writeAttributeFor(prop1);
             await this.registry.setAttribute(oneHundred, canWriteProp1, 3, notes, { from: owner })
             await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: oneHundred })
         })
 
         it('owner can let others write attribute value', async function () {
-            const canWriteProp1 = await this.registry.writeAttributeFor(prop1);
+            const canWriteProp1 = writeAttributeFor(prop1);
             await this.registry.setAttributeValue(oneHundred, canWriteProp1, 3, { from: owner })
             await this.registry.setAttributeValue(anotherAccount, prop1, 3, { from: oneHundred })
         })
 
         it('others can only write what they are allowed to', async function () {
-            const canWriteProp1 = await this.registry.writeAttributeFor(prop1);
+            const canWriteProp1 = writeAttributeFor(prop1);
             await this.registry.setAttribute(oneHundred, canWriteProp1, 3, notes, { from: owner })
             await assertRevert(this.registry.setAttribute(anotherAccount, prop2, 3, notes, { from: oneHundred }))
             await assertRevert(this.registry.setAttributeValue(anotherAccount, prop2, 3, { from: oneHundred }))
-        })
-    })
-
-    describe('Attribute get Combination', async function(){
-        const attr1 = "foo"
-        const attr2 = "bar"
-        const attr3 = "blarg"
-        
-        it('has both attributes', async function(){
-            await this.registry.setAttribute(oneHundred, attr1, 1, notes, { from: owner })
-            await this.registry.setAttribute(oneHundred, attr2, 1, notes, { from: owner })
-            const result = await this.registry.hasBothAttributes(oneHundred, attr1, attr2)
-            assert.equal(result,true)
-        })
-
-        it('does not have both attributes', async function(){
-            await this.registry.setAttribute(oneHundred, attr1, 1, notes, { from: owner })
-            await this.registry.setAttribute(oneHundred, attr2, 1, notes, { from: owner })
-            const result = await this.registry.hasBothAttributes(oneHundred, attr1, attr3)
-            assert.equal(result,false)
-        })
-
-        it('has either attributes',async function(){
-            await this.registry.setAttribute(oneHundred, attr3, 1, notes, { from: owner })
-            const result = await this.registry.hasEitherAttribute(oneHundred, attr1, attr3)
-            assert.equal(result,true)
-        })
-
-        it('has neither attributes',async function(){
-            const result = await this.registry.hasEitherAttribute(oneHundred, attr1, attr3)
-            assert.equal(result,false)
-        })
-
-        it('either have attributes',async function(){
-            await this.registry.setAttribute(oneHundred, attr1, 1, notes, { from: owner })
-            const result = await this.registry.eitherHaveAttribute(oneHundred, anotherAccount, attr1)
-            assert.equal(result,true)
-        })
-
-        it('neither have attributes',async function(){
-            const result = await this.registry.eitherHaveAttribute(oneHundred, anotherAccount, attr3)
-            assert.equal(result,false)
-        })
-
-        it('has one but not the other',async function(){
-            await this.registry.setAttribute(oneHundred, attr1, 1, notes, { from: owner })
-            let result = await this.registry.hasAttribute1ButNotAttribute2(oneHundred, attr1, attr3)
-            assert.equal(result,true)
-            await this.registry.setAttribute(oneHundred, attr3, 1, notes, { from: owner })
-            result = await this.registry.hasAttribute1ButNotAttribute2(oneHundred, attr1, attr3)
-            assert.equal(result,false)
-        })
-
-        it('both have Attribute', async function(){
-            await this.registry.setAttribute(oneHundred, attr1, 1, notes, { from: owner })
-            await this.registry.setAttribute(anotherAccount, attr1, 1, notes, { from: owner })
-            const result = await this.registry.bothHaveAttribute(oneHundred, anotherAccount, attr1)
-            assert.equal(result,true)
-        })
-
-        it ('have attributes', async function(){
-            await this.registry.setAttribute(oneHundred, attr1, 1, notes, { from: owner })
-            await this.registry.setAttribute(anotherAccount, attr3, 1, notes, { from: owner })
-            const result = await this.registry.haveAttributes(oneHundred, attr1, anotherAccount, attr3)
-            assert.equal(result,true)
-        })
-
-        it ('have either attributes', async function(){
-            await this.registry.setAttribute(oneHundred, attr1, 1, notes, { from: owner })
-            const result = await this.registry.haveEitherAttribute(anotherAccount, attr3, oneHundred, attr1)
-            assert.equal(result,true)
         })
     })
 
@@ -199,24 +130,16 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
             await assertRevert(this.registry.requireCanTransferFrom(anotherAccount, oneHundred, owner));
         });
         it('handle deposit addresses', async function() {
-            const isDepositAddressBefore = await this.registry.isDepositAddress(anotherAccount);
-            assert.equal(isDepositAddressBefore, false);
-            await this.registry.setAttributeValue(anotherAccount.slice(0, -5), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
-            const isDepositAddressAfter = await this.registry.isDepositAddress(anotherAccount);
-            assert.equal(isDepositAddressAfter, true);
-            const depositAddress = await this.registry.getDepositAddress(anotherAccount);
-            assert.equal(depositAddress, anotherAccount);
-            const depositAddress0 = await this.registry.getDepositAddress(anotherAccount.slice(0, -5) + '00000');
-            assert.equal(depositAddress0, anotherAccount);
-            const result = await this.registry.requireCanTransfer(oneHundred, anotherAccount.slice(0, -5) + '00000');
+            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
+            const result = await this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00000'));
             assert.equal(result[0], anotherAccount);
             assert.equal(result[1], false);
-            const resultFrom = await this.registry.requireCanTransferFrom(oneHundred, oneHundred, anotherAccount.slice(0, -5) + 'fffff');
+            const resultFrom = await this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'fffff'));
             assert.equal(resultFrom[0], anotherAccount);
             assert.equal(resultFrom[1], false);
             await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
-            await assertRevert(this.registry.requireCanTransfer(oneHundred, anotherAccount.slice(0, -5) + 'eeeee'));
-            await assertRevert(this.registry.requireCanTransferFrom(oneHundred, oneHundred, anotherAccount.slice(0, -5) + 'eeeee'));
+            await assertRevert(this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
+            await assertRevert(this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
         });
         it('return true when recipient is a registered contract', async function() {
             await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, anotherAccount, { from: owner });
@@ -228,17 +151,17 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
             assert.equal(resultFrom[1], true);
         });
         it ('handles deposit addresses that are registered contracts', async function() {
-            await this.registry.setAttributeValue(anotherAccount.slice(0, -5), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
+            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
             await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, anotherAccount, { from: owner });
-            const resultContract = await this.registry.requireCanTransfer(oneHundred, anotherAccount.slice(0, -5) + '00000');
+            const resultContract = await this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00000'));
             assert.equal(resultContract[0], anotherAccount);
             assert.equal(resultContract[1], true);
-            const resultFromContract = await this.registry.requireCanTransferFrom(oneHundred, oneHundred, anotherAccount.slice(0, -5) + 'fffff');
+            const resultFromContract = await this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'fffff'));
             assert.equal(resultFromContract[0], anotherAccount);
             assert.equal(resultFromContract[1], true);
             await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
-            await assertRevert(this.registry.requireCanTransfer(oneHundred, anotherAccount.slice(0, -5) + 'eeeee'));
-            await assertRevert(this.registry.requireCanTransferFrom(oneHundred, oneHundred, anotherAccount.slice(0, -5) + 'eeeee'));
+            await assertRevert(this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
+            await assertRevert(this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
         });
     })
 
@@ -260,9 +183,9 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
             assert.equal(result[1], false);
         })
         it('returns deposit address', async function() {
-            const depositAddress = anotherAccount.slice(0, -5) + '00055';
+            const depositAddress = web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00055');
             await this.registry.setAttributeValue(depositAddress, HAS_PASSED_KYC_AML, 1, { from: owner });
-            await this.registry.setAttributeValue(anotherAccount.slice(0, -5), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
+            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
             const result = await this.registry.requireCanMint(depositAddress);
             assert.equal(result[0], anotherAccount);
             assert.equal(result[1], false);
@@ -275,10 +198,10 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
             assert.equal(result[1], true);
         })
         it('handles registered deposit addresses', async function() {
-            const depositAddress = anotherAccount.slice(0, -5) + '00055';
+            const depositAddress = web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00055');
             await this.registry.setAttributeValue(depositAddress, HAS_PASSED_KYC_AML, 1, { from: owner });
             await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, 1, { from: owner });
-            await this.registry.setAttributeValue(anotherAccount.slice(0, -5), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
+            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
             const result = await this.registry.requireCanMint(depositAddress);
             assert.equal(result[0], anotherAccount);
             assert.equal(result[1], true);
@@ -323,14 +246,14 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
 
         it ('owner can transfer out ether in the contract address',async function(){
             const emptyAddress = "0x5fef93e79a73b28a9113a618aabf84f2956eb3ba"
-            const emptyAddressBalance = web3.fromWei(web3.eth.getBalance(emptyAddress), 'ether').toNumber()
+            const emptyAddressBalance = web3.utils.fromWei((await web3.eth.getBalance(emptyAddress)), 'ether')
 
             const forceEther = await ForceEther.new({ from: owner, value: "10000000000000000000" })
             await forceEther.destroyAndSend(this.registry.address, { from: owner })
-            const registryInitialWithForcedEther = web3.fromWei(web3.eth.getBalance(this.registry.address), 'ether').toNumber()
+            const registryInitialWithForcedEther = web3.utils.fromWei((await web3.eth.getBalance(this.registry.address)), 'ether')
             await this.registry.reclaimEther(emptyAddress, { from: owner })
-            const registryFinalBalance = web3.fromWei(web3.eth.getBalance(this.registry.address), 'ether').toNumber()
-            const emptyAddressFinalBalance = web3.fromWei(web3.eth.getBalance(emptyAddress), 'ether').toNumber()
+            const registryFinalBalance = web3.utils.fromWei((await web3.eth.getBalance(this.registry.address)), 'ether')
+            const emptyAddressFinalBalance = web3.utils.fromWei((await web3.eth.getBalance(emptyAddress)), 'ether')
             assert.equal(registryInitialWithForcedEther,10)
             assert.equal(registryFinalBalance,0)
             assert.equal(emptyAddressFinalBalance,10)

--- a/test/helpers/bytes32.js
+++ b/test/helpers/bytes32.js
@@ -1,0 +1,3 @@
+module.exports = function bytes32(str) {
+  return web3.utils.padRight(web3.utils.toHex(str), 64);
+}

--- a/test/helpers/writeAttributeFor.js
+++ b/test/helpers/writeAttributeFor.js
@@ -1,0 +1,12 @@
+const canWriteTo = Buffer.from(web3.utils.sha3("canWriteTo-").slice(2), 'hex');
+
+function writeAttributeFor(attribute) {
+  let bytes = Buffer.from(attribute.slice(2), 'hex');
+  for (let index = 0; index < canWriteTo.length; index++) {
+    bytes[index] ^= canWriteTo[index];
+  }
+  return web3.utils.sha3('0x' + bytes.toString('hex'));
+}
+
+
+module.exports = writeAttributeFor;

--- a/truffle.js
+++ b/truffle.js
@@ -5,10 +5,20 @@ var HDWalletProvider = require("truffle-hdwallet-provider");
 
 module.exports = {
   solc: {
+    version: "0.4.23",
     optimizer: {
       enabled: true,
-      runs: 200
+      runs: 20000
     }
+  },
+  compilers: {
+    solc: {
+      version: "0.4.23",
+      optimizer: {
+        enabled: true,
+        runs: 20000
+      }
+    },
   },
   networks: {
     development: {


### PR DESCRIPTION

#### Changes
This removes a bunch of unnecessary read access methods.
In order to privatize canWriteFor, I pull a helper method from the scripts repo.
The behavior of web3.sha3 differs from web3.utils.sha3, so I also upgrade to Truffle 5.
Reviewers @terryli0095