### PR TITLE
Write-Through Registry

### DIFF
--- a/contracts/ProvisionalRegistry.sol
+++ b/contracts/ProvisionalRegistry.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.4.23;
+
+import "./Registry.sol";
+
+contract ProvisionalRegistry is Registry {
+    function syncAttributes(address[] _addresses, bytes32[] _attributes) external {
+        RegistryClone replica = clone();
+        for (uint i = 0; i < _attributes.length; i++) {
+            address who = _addresses[i];
+            bytes32 attribute = _attributes[i];
+            replica.syncAttributeValue(who, attribute, attributes[who][attribute].value);
+        }
+    }
+
+    function requireCanTransfer(address _from, address _to) public view returns (address, bool) {
+        require (attributes[_from][IS_BLACKLISTED].value == 0, "blacklisted");
+        uint256 depositAddressValue = attributes[address(uint256(_to) >> 20)][IS_DEPOSIT_ADDRESS].value;
+        if (depositAddressValue != 0) {
+            _to = address(depositAddressValue);
+        }
+        require (attributes[_to][IS_BLACKLISTED].value == 0, "blacklisted");
+        return (_to, attributes[_to][IS_REGISTERED_CONTRACT].value != 0);
+    }
+
+    function requireCanTransferFrom(address _sender, address _from, address _to) public view returns (address, bool) {
+        require (attributes[_sender][IS_BLACKLISTED].value == 0, "blacklisted");
+        return requireCanTransfer(_from, _to);
+    }
+
+    function requireCanMint(address _to) public view returns (address, bool) {
+        require (attributes[_to][HAS_PASSED_KYC_AML].value != 0);
+        require (attributes[_to][IS_BLACKLISTED].value == 0, "blacklisted");
+        uint256 depositAddressValue = attributes[address(uint256(_to) >> 20)][IS_DEPOSIT_ADDRESS].value;
+        if (depositAddressValue != 0) {
+            _to = address(depositAddressValue);
+        }
+        return (_to, attributes[_to][IS_REGISTERED_CONTRACT].value != 0);
+    }
+
+    function requireCanBurn(address _from) public view {
+        require (attributes[_from][CAN_BURN].value != 0);
+        require (attributes[_from][IS_BLACKLISTED].value == 0);
+    }
+}

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -74,35 +74,6 @@ contract Registry {
         return attributes[_who][_attribute].value != 0;
     }
 
-    function requireCanTransfer(address _from, address _to) public view returns (address, bool) {
-        require (attributes[_from][IS_BLACKLISTED].value == 0, "blacklisted");
-        uint256 depositAddressValue = attributes[address(uint256(_to) >> 20)][IS_DEPOSIT_ADDRESS].value;
-        if (depositAddressValue != 0) {
-            _to = address(depositAddressValue);
-        }
-        require (attributes[_to][IS_BLACKLISTED].value == 0, "blacklisted");
-        return (_to, attributes[_to][IS_REGISTERED_CONTRACT].value != 0);
-    }
-
-    function requireCanTransferFrom(address _sender, address _from, address _to) public view returns (address, bool) {
-        require (attributes[_sender][IS_BLACKLISTED].value == 0, "blacklisted");
-        return requireCanTransfer(_from, _to);
-    }
-
-    function requireCanMint(address _to) public view returns (address, bool) {
-        require (attributes[_to][HAS_PASSED_KYC_AML].value != 0);
-        require (attributes[_to][IS_BLACKLISTED].value == 0, "blacklisted");
-        uint256 depositAddressValue = attributes[address(uint256(_to) >> 20)][IS_DEPOSIT_ADDRESS].value;
-        if (depositAddressValue != 0) {
-            _to = address(depositAddressValue);
-        }
-        return (_to, attributes[_to][IS_REGISTERED_CONTRACT].value != 0);
-    }
-
-    function requireCanBurn(address _from) public view {
-        require (attributes[_from][CAN_BURN].value != 0);
-        require (attributes[_from][IS_BLACKLISTED].value == 0);
-    }
 
     // Returns the exact value of the attribute, as well as its metadata
     function getAttribute(address _who, bytes32 _attribute) public view returns (uint256, bytes32, address, uint256) {
@@ -131,16 +102,7 @@ contract Registry {
         token.transfer(_to, balance);
     }
 
-    function syncAttributes(address[] _addresses, bytes32[] _attributes) external {
-        RegistryClone replica = clone();
-        for (uint i = 0; i < _attributes.length; i++) {
-            address who = _addresses[i];
-            bytes32 attribute = _attributes[i];
-            replica.syncAttributeValue(who, attribute, attributes[who][attribute].value);
-        }
-    }
-
-    /**
+   /**
     * @dev Throws if called by any account other than the owner.
     */
     modifier onlyOwner() {

--- a/contracts/RegistryToken.sol
+++ b/contracts/RegistryToken.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.4.23;
+
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+
+import "./HasRegistry.sol";
+
+contract RegistryToken is HasRegistry {
+    mapping(address => mapping(bytes32 => uint256)) attributes;
+    
+    modifier onlyRegistry {
+      require(msg.sender == address(registry));
+      _;
+    }
+
+    function syncAttributeValue(address _who, bytes32 _attribute, uint256 _value) public onlyRegistry {
+        attributes[_who][_attribute] = _value;
+    }
+}

--- a/contracts/mocks/RegistryMock.sol
+++ b/contracts/mocks/RegistryMock.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.23;
 import "../Registry.sol";
+import "../ProvisionalRegistry.sol";
 
 contract RegistryMock is Registry {
 
@@ -27,4 +28,7 @@ contract RegistryMock is Registry {
     function clone() internal view returns (RegistryClone) {
         return _clone;
     }
+}
+
+contract ProvisionalRegistryMock is RegistryMock, ProvisionalRegistry {
 }

--- a/contracts/mocks/RegistryMock.sol
+++ b/contracts/mocks/RegistryMock.sol
@@ -3,6 +3,8 @@ import "../Registry.sol";
 
 contract RegistryMock is Registry {
 
+    RegistryClone _clone;
+
     /**
     * @dev sets the original `owner` of the contract to the sender
     * at construction. Must then be reinitialized
@@ -18,4 +20,11 @@ contract RegistryMock is Registry {
         initialized = true;
     }
 
+    function setClone(RegistryClone __clone) public {
+        _clone = __clone;
+    }
+
+    function clone() internal view returns (RegistryClone) {
+        return _clone;
+    }
 }

--- a/contracts/mocks/RegistryTokenMock.sol
+++ b/contracts/mocks/RegistryTokenMock.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.4.23;
+
+import "../RegistryToken.sol";
+
+contract RegistryTokenMock is RegistryToken {
+
+    function getAttributeValue(address _who, bytes32 _attribute) public view returns (uint256) {
+        return attributes[_who][_attribute];
+    }
+
+}

--- a/test/ProvisionalRegistry.test.js
+++ b/test/ProvisionalRegistry.test.js
@@ -1,0 +1,66 @@
+import assertRevert from './helpers/assertRevert'
+const RegistryMock = artifacts.require('ProvisionalRegistryMock')
+const MockToken = artifacts.require("MockToken")
+const ForceEther = artifacts.require("ForceEther")
+const RegistryTokenMock = artifacts.require('RegistryTokenMock')
+
+const BN = web3.utils.toBN;
+const writeAttributeFor = require('./helpers/writeAttributeFor.js')
+const bytes32 = require('./helpers/bytes32.js')
+
+contract('ProvisionalRegistry', function ([_, owner, oneHundred, anotherAccount]) {
+    const prop1 = web3.utils.sha3("foo")
+    const IS_BLACKLISTED = bytes32('isBlacklisted');
+    const IS_REGISTERED_CONTRACT = bytes32('isRegisteredContract');
+    const IS_DEPOSIT_ADDRESS = bytes32('isDepositAddress');
+    const HAS_PASSED_KYC_AML = bytes32("hasPassedKYC/AML");
+    const CAN_BURN = bytes32("canBurn");
+    const prop2 = bytes32("bar")
+    const notes = bytes32("blarg")
+    
+    beforeEach(async function () {
+        this.registry = await RegistryMock.new({ from: owner })
+        await this.registry.initialize({ from: owner })
+        this.registryToken = await RegistryTokenMock.new({ from: owner })
+        await this.registryToken.setRegistry(this.registry.address, { from: owner })
+        await this.registry.setClone(this.registryToken.address);
+    })
+
+    describe('sync', function() {
+        beforeEach(async function() {
+            await this.registry.setAttributeValue(oneHundred, prop1, 3, { from: owner });
+        })
+        it('writes sync', async function() {
+            assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
+        })
+        it('syncs prior writes', async function() {
+            let token2 = await RegistryTokenMock.new({ from: owner });
+            await token2.setRegistry(this.registry.address, { from: owner });
+            await this.registry.setClone(token2.address);
+            assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
+            assert.equal(0, await token2.getAttributeValue(oneHundred, prop1));
+
+            await this.registry.syncAttributes([oneHundred], [prop1]);
+            assert.equal(3, await token2.getAttributeValue(oneHundred, prop1));
+        })
+        it('syncs multiple prior writes', async function() {
+
+            await this.registry.setAttributeValue(oneHundred, prop2, 4, { from: owner});
+            await this.registry.setAttributeValue(anotherAccount, prop2, 5, { from: owner});
+            await this.registry.setAttributeValue(owner, CAN_BURN, 6, { from: owner});
+            let token2 = await RegistryTokenMock.new({ from: owner });
+            await token2.setRegistry(this.registry.address, { from: owner });
+            await this.registry.setClone(token2.address);
+            assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
+            assert.equal(0, await token2.getAttributeValue(oneHundred, prop1));
+
+            await this.registry.syncAttributes([oneHundred, oneHundred, anotherAccount, owner], [prop1, prop2, prop2, CAN_BURN]);
+            assert.equal(3, await token2.getAttributeValue(oneHundred, prop1));
+            assert.equal(4, await token2.getAttributeValue(oneHundred, prop2));
+            assert.equal(5, await token2.getAttributeValue(anotherAccount, prop2));
+            assert.equal(6, await token2.getAttributeValue(owner, CAN_BURN));
+        })
+    })
+
+
+})

--- a/test/ProvisionalRegistry.test.js
+++ b/test/ProvisionalRegistry.test.js
@@ -118,14 +118,14 @@ contract('ProvisionalRegistry', function ([_, owner, oneHundred, anotherAccount]
 
     describe('requireCanMint', async function() {
         it('reverts without KYCAML flag', async function() {
-            assertRevert(this.registry.requireCanMint(owner));
-            assertRevert(this.registry.requireCanMint(oneHundred));
-            assertRevert(this.registry.requireCanMint(anotherAccount));
+            await assertRevert(this.registry.requireCanMint(owner));
+            await assertRevert(this.registry.requireCanMint(oneHundred));
+            await assertRevert(this.registry.requireCanMint(anotherAccount));
         })
         it('reverts for blacklisted recipient', async function() {
             await this.registry.setAttributeValue(anotherAccount, HAS_PASSED_KYC_AML, 1, { from: owner });
             await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
-            assertRevert(this.registry.requireCanMint(anotherAccount));
+            await assertRevert(this.registry.requireCanMint(anotherAccount));
         })
         it('returns false for whitelisted accounts', async function() {
             await this.registry.setAttributeValue(anotherAccount, HAS_PASSED_KYC_AML, 1, { from: owner });
@@ -161,20 +161,20 @@ contract('ProvisionalRegistry', function ([_, owner, oneHundred, anotherAccount]
 
     describe('requireCanBurn', async function() {
         it('reverts without CAN_BURN flag', async function() {
-            assertRevert(this.registry.requireCanBurn(owner));
-            assertRevert(this.registry.requireCanBurn(oneHundred));
-            assertRevert(this.registry.requireCanBurn(anotherAccount));
+            await assertRevert(this.registry.requireCanBurn(owner));
+            await assertRevert(this.registry.requireCanBurn(oneHundred));
+            await assertRevert(this.registry.requireCanBurn(anotherAccount));
         })
         it('works with CAN_BURN flag', async function () {
             await this.registry.setAttributeValue(anotherAccount, CAN_BURN, 1, { from: owner });
             await this.registry.requireCanBurn(anotherAccount);
-            assertRevert(this.registry.requireCanBurn(owner));
+            await assertRevert(this.registry.requireCanBurn(owner));
         })
         it('reverts for blacklisted accounts', async function() {
             await this.registry.setAttributeValue(anotherAccount, CAN_BURN, 1, { from: owner });
             await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
-            assertRevert(this.registry.requireCanBurn(anotherAccount));
-            assertRevert(this.registry.requireCanBurn(owner));
+            await assertRevert(this.registry.requireCanBurn(anotherAccount));
+            await assertRevert(this.registry.requireCanBurn(owner));
         })
     })
 

--- a/test/ProvisionalRegistry.test.js
+++ b/test/ProvisionalRegistry.test.js
@@ -1,22 +1,12 @@
-import assertRevert from './helpers/assertRevert'
-const RegistryMock = artifacts.require('ProvisionalRegistryMock')
-const MockToken = artifacts.require("MockToken")
-const ForceEther = artifacts.require("ForceEther")
+const ProvisionalRegistryMock = artifacts.require('ProvisionalRegistryMock')
 const RegistryTokenMock = artifacts.require('RegistryTokenMock')
 
-const BN = web3.utils.toBN;
-const writeAttributeFor = require('./helpers/writeAttributeFor.js')
 const bytes32 = require('./helpers/bytes32.js')
 
 contract('ProvisionalRegistry', function ([_, owner, oneHundred, anotherAccount]) {
     const prop1 = web3.utils.sha3("foo")
-    const IS_BLACKLISTED = bytes32('isBlacklisted');
-    const IS_REGISTERED_CONTRACT = bytes32('isRegisteredContract');
-    const IS_DEPOSIT_ADDRESS = bytes32('isDepositAddress');
-    const HAS_PASSED_KYC_AML = bytes32("hasPassedKYC/AML");
     const CAN_BURN = bytes32("canBurn");
     const prop2 = bytes32("bar")
-    const notes = bytes32("blarg")
     
     beforeEach(async function () {
         this.registry = await RegistryMock.new({ from: owner })

--- a/test/ProvisionalRegistry.test.js
+++ b/test/ProvisionalRegistry.test.js
@@ -1,3 +1,4 @@
+import registryTests from './Registry'
 const ProvisionalRegistryMock = artifacts.require('ProvisionalRegistryMock')
 const RegistryTokenMock = artifacts.require('RegistryTokenMock')
 
@@ -20,6 +21,7 @@ contract('ProvisionalRegistry', function ([_, owner, oneHundred, anotherAccount]
         await this.registryToken.setRegistry(this.registry.address, { from: owner })
         await this.registry.setClone(this.registryToken.address);
     })
+    registryTests([owner, oneHundred, anotherAccount])
 
     describe('sync', function() {
         beforeEach(async function() {

--- a/test/ProvisionalRegistry.test.js
+++ b/test/ProvisionalRegistry.test.js
@@ -1,15 +1,20 @@
 const ProvisionalRegistryMock = artifacts.require('ProvisionalRegistryMock')
 const RegistryTokenMock = artifacts.require('RegistryTokenMock')
 
+import assertRevert from './helpers/assertRevert'
 const bytes32 = require('./helpers/bytes32.js')
 
 contract('ProvisionalRegistry', function ([_, owner, oneHundred, anotherAccount]) {
     const prop1 = web3.utils.sha3("foo")
+    const IS_BLACKLISTED = bytes32('isBlacklisted');
+    const IS_REGISTERED_CONTRACT = bytes32('isRegisteredContract');
+    const IS_DEPOSIT_ADDRESS = bytes32('isDepositAddress');
+    const HAS_PASSED_KYC_AML = bytes32("hasPassedKYC/AML");
     const CAN_BURN = bytes32("canBurn");
     const prop2 = bytes32("bar")
     
     beforeEach(async function () {
-        this.registry = await RegistryMock.new({ from: owner })
+        this.registry = await ProvisionalRegistryMock.new({ from: owner })
         await this.registry.initialize({ from: owner })
         this.registryToken = await RegistryTokenMock.new({ from: owner })
         await this.registryToken.setRegistry(this.registry.address, { from: owner })
@@ -49,6 +54,127 @@ contract('ProvisionalRegistry', function ([_, owner, oneHundred, anotherAccount]
             assert.equal(4, await token2.getAttributeValue(oneHundred, prop2));
             assert.equal(5, await token2.getAttributeValue(anotherAccount, prop2));
             assert.equal(6, await token2.getAttributeValue(owner, CAN_BURN));
+        })
+    })
+
+    describe('requireCanTransfer and requireCanTransferFrom', async function() {
+        it('return _to and false when nothing set', async function() {
+            const result = await this.registry.requireCanTransfer(oneHundred, anotherAccount);
+            assert.equal(result[0], anotherAccount);
+            assert.equal(result[1], false);
+            const resultFrom = await this.registry.requireCanTransferFrom(owner, oneHundred, anotherAccount);
+            assert.equal(resultFrom[0], anotherAccount);
+            assert.equal(resultFrom[1], false);
+        });
+        it('revert when _from is blacklisted', async function() {
+            await this.registry.setAttributeValue(oneHundred, IS_BLACKLISTED, 1, { from: owner });
+            await assertRevert(this.registry.requireCanTransfer(oneHundred, anotherAccount));
+            await assertRevert(this.registry.requireCanTransferFrom(owner, oneHundred, anotherAccount));
+        });
+        it('revert when _to is blacklisted', async function() {
+            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
+            await assertRevert(this.registry.requireCanTransfer(oneHundred, anotherAccount));
+            await assertRevert(this.registry.requireCanTransferFrom(owner, oneHundred, anotherAccount));
+        });
+        it('revert when _sender is blacklisted', async function() {
+            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
+            await assertRevert(this.registry.requireCanTransferFrom(anotherAccount, oneHundred, owner));
+        });
+        it('handle deposit addresses', async function() {
+            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
+            const result = await this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00000'));
+            assert.equal(result[0], anotherAccount);
+            assert.equal(result[1], false);
+            const resultFrom = await this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'fffff'));
+            assert.equal(resultFrom[0], anotherAccount);
+            assert.equal(resultFrom[1], false);
+            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
+            await assertRevert(this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
+            await assertRevert(this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
+        });
+        it('return true when recipient is a registered contract', async function() {
+            await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, anotherAccount, { from: owner });
+            const result = await this.registry.requireCanTransfer(oneHundred, anotherAccount);
+            assert.equal(result[0], anotherAccount);
+            assert.equal(result[1], true);
+            const resultFrom = await this.registry.requireCanTransferFrom(owner, oneHundred, anotherAccount);
+            assert.equal(resultFrom[0], anotherAccount);
+            assert.equal(resultFrom[1], true);
+        });
+        it ('handles deposit addresses that are registered contracts', async function() {
+            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
+            await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, anotherAccount, { from: owner });
+            const resultContract = await this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00000'));
+            assert.equal(resultContract[0], anotherAccount);
+            assert.equal(resultContract[1], true);
+            const resultFromContract = await this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'fffff'));
+            assert.equal(resultFromContract[0], anotherAccount);
+            assert.equal(resultFromContract[1], true);
+            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
+            await assertRevert(this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
+            await assertRevert(this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
+        });
+    })
+
+    describe('requireCanMint', async function() {
+        it('reverts without KYCAML flag', async function() {
+            assertRevert(this.registry.requireCanMint(owner));
+            assertRevert(this.registry.requireCanMint(oneHundred));
+            assertRevert(this.registry.requireCanMint(anotherAccount));
+        })
+        it('reverts for blacklisted recipient', async function() {
+            await this.registry.setAttributeValue(anotherAccount, HAS_PASSED_KYC_AML, 1, { from: owner });
+            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
+            assertRevert(this.registry.requireCanMint(anotherAccount));
+        })
+        it('returns false for whitelisted accounts', async function() {
+            await this.registry.setAttributeValue(anotherAccount, HAS_PASSED_KYC_AML, 1, { from: owner });
+            const result = await this.registry.requireCanMint(anotherAccount);
+            assert.equal(result[0], anotherAccount);
+            assert.equal(result[1], false);
+        })
+        it('returns deposit address', async function() {
+            const depositAddress = web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00055');
+            await this.registry.setAttributeValue(depositAddress, HAS_PASSED_KYC_AML, 1, { from: owner });
+            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
+            const result = await this.registry.requireCanMint(depositAddress);
+            assert.equal(result[0], anotherAccount);
+            assert.equal(result[1], false);
+        })
+        it('returns true for registered', async function() {
+            await this.registry.setAttributeValue(anotherAccount, HAS_PASSED_KYC_AML, 1, { from: owner });
+            await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, 1, { from: owner });
+            const result = await this.registry.requireCanMint(anotherAccount);
+            assert.equal(result[0], anotherAccount);
+            assert.equal(result[1], true);
+        })
+        it('handles registered deposit addresses', async function() {
+            const depositAddress = web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00055');
+            await this.registry.setAttributeValue(depositAddress, HAS_PASSED_KYC_AML, 1, { from: owner });
+            await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, 1, { from: owner });
+            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
+            const result = await this.registry.requireCanMint(depositAddress);
+            assert.equal(result[0], anotherAccount);
+            assert.equal(result[1], true);
+        })
+    })
+
+    describe('requireCanBurn', async function() {
+        it('reverts without CAN_BURN flag', async function() {
+            assertRevert(this.registry.requireCanBurn(owner));
+            assertRevert(this.registry.requireCanBurn(oneHundred));
+            assertRevert(this.registry.requireCanBurn(anotherAccount));
+        })
+        it('works with CAN_BURN flag', async function () {
+            await this.registry.setAttributeValue(anotherAccount, CAN_BURN, 1, { from: owner });
+            await this.registry.requireCanBurn(anotherAccount);
+            assertRevert(this.registry.requireCanBurn(owner));
+        })
+        it('reverts for blacklisted accounts', async function() {
+            await this.registry.setAttributeValue(anotherAccount, CAN_BURN, 1, { from: owner });
+            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
+            assertRevert(this.registry.requireCanBurn(anotherAccount));
+            assertRevert(this.registry.requireCanBurn(owner));
         })
     })
 

--- a/test/Registry.js
+++ b/test/Registry.js
@@ -1,0 +1,135 @@
+const MockToken = artifacts.require("MockToken")
+const ForceEther = artifacts.require("ForceEther")
+
+import assertRevert from './helpers/assertRevert'
+const writeAttributeFor = require('./helpers/writeAttributeFor.js')
+const bytes32 = require('./helpers/bytes32.js')
+
+function registryTests([owner, oneHundred, anotherAccount]) {
+    describe('--Registry Tests--', function () {
+        const prop1 = web3.utils.sha3("foo")
+        const prop2 = bytes32("bar")
+        const notes = bytes32("blarg")
+        
+        describe('ownership functions', function(){
+            it('cannot be reinitialized', async function () {
+                await assertRevert(this.registry.initialize({ from: owner }))
+            })
+            it('can transfer ownership', async function () {
+                await this.registry.transferOwnership(anotherAccount,{ from: owner })
+                assert.equal(await this.registry.pendingOwner(),anotherAccount)
+            })
+            it('non owner cannot transfer ownership', async function () {
+                await assertRevert(this.registry.transferOwnership(anotherAccount,{ from: anotherAccount }))
+            })
+            it('can claim ownership', async function () {
+                await this.registry.transferOwnership(anotherAccount,{ from: owner })
+                await this.registry.claimOwnership({ from: anotherAccount })
+                assert.equal(await this.registry.owner(),anotherAccount)
+            })
+            it('only pending owner can claim ownership', async function () {
+                await this.registry.transferOwnership(anotherAccount,{ from: owner })
+                await assertRevert(this.registry.claimOwnership({ from: oneHundred }))
+            })
+        })
+        describe('read/write', function () {
+            it('works for owner', async function () {
+                const { receipt } = await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: owner })
+                const attr = await this.registry.getAttribute(anotherAccount, prop1)
+                assert.equal(attr[0], 3)
+                assert.equal(attr[1], notes)
+                assert.equal(attr[2], owner)
+                assert.equal(attr[3], (await web3.eth.getBlock(receipt.blockNumber)).timestamp)
+                const hasAttr = await this.registry.hasAttribute(anotherAccount, prop1)
+                assert.equal(hasAttr, true)
+                const value = await this.registry.getAttributeValue(anotherAccount, prop1)
+                assert.equal(Number(value),3)
+                const adminAddress = await this.registry.getAttributeAdminAddr(anotherAccount, prop1)
+                assert.equal(adminAddress, owner)
+                const timestamp = await this.registry.getAttributeTimestamp(anotherAccount, prop1)
+                assert.equal(timestamp, (await web3.eth.getBlock(receipt.blockNumber)).timestamp)
+            })
+
+            it('sets only desired attribute', async function () {
+                await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: owner })
+                const attr = await this.registry.getAttribute(anotherAccount, prop2)
+                assert.equal(attr[0], 0)
+                assert.equal(attr[1], '0x0000000000000000000000000000000000000000000000000000000000000000')
+                assert.equal(attr[2], 0)
+                const hasAttr = await this.registry.hasAttribute(anotherAccount, prop2)
+                assert.equal(hasAttr, false)
+            })
+
+            it('emits an event', async function () {
+                const { logs } = await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: owner })
+
+                assert.equal(logs.length, 1)
+                assert.equal(logs[0].event, 'SetAttribute')
+                assert.equal(logs[0].args.who, anotherAccount)
+                assert.equal(logs[0].args.attribute, prop1)
+                assert.equal(logs[0].args.value, 3)
+                assert.equal(logs[0].args.notes, notes)
+                assert.equal(logs[0].args.adminAddr, owner)
+            })
+
+            it('cannot be called by random non-owner', async function () {
+                await assertRevert(this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: oneHundred }))
+            })
+
+            it('owner can let others write', async function () {
+                const canWriteProp1 = writeAttributeFor(prop1);
+                await this.registry.setAttribute(oneHundred, canWriteProp1, 3, notes, { from: owner })
+                await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: oneHundred })
+            })
+
+            it('owner can let others write attribute value', async function () {
+                const canWriteProp1 = writeAttributeFor(prop1);
+                await this.registry.setAttributeValue(oneHundred, canWriteProp1, 3, { from: owner })
+                await this.registry.setAttributeValue(anotherAccount, prop1, 3, { from: oneHundred })
+            })
+
+            it('others can only write what they are allowed to', async function () {
+                const canWriteProp1 = writeAttributeFor(prop1);
+                await this.registry.setAttribute(oneHundred, canWriteProp1, 3, notes, { from: owner })
+                await assertRevert(this.registry.setAttribute(anotherAccount, prop2, 3, notes, { from: oneHundred }))
+                await assertRevert(this.registry.setAttributeValue(anotherAccount, prop2, 3, { from: oneHundred }))
+            })
+        })
+
+        describe('no ether and no tokens', function () {
+            beforeEach(async function () {
+                this.token = await MockToken.new( this.registry.address, 100, { from: owner })
+            })
+
+            it ('owner can transfer out token in the contract address ',async function(){
+                await this.registry.reclaimToken(this.token.address, owner, { from: owner })
+            })
+
+            it('cannot transfer ether to contract address',async function(){
+                await assertRevert(this.registry.sendTransaction({ 
+                    value: 33, 
+                    from: owner, 
+                    gas: 300000 
+                 }));         
+            })
+
+            it ('owner can transfer out ether in the contract address',async function(){
+                const emptyAddress = "0x5fef93e79a73b28a9113a618aabf84f2956eb3ba"
+                const emptyAddressBalance = web3.utils.fromWei((await web3.eth.getBalance(emptyAddress)), 'ether')
+
+                const forceEther = await ForceEther.new({ from: owner, value: "10000000000000000000" })
+                await forceEther.destroyAndSend(this.registry.address, { from: owner })
+                const registryInitialWithForcedEther = web3.utils.fromWei((await web3.eth.getBalance(this.registry.address)), 'ether')
+                await this.registry.reclaimEther(emptyAddress, { from: owner })
+                const registryFinalBalance = web3.utils.fromWei((await web3.eth.getBalance(this.registry.address)), 'ether')
+                const emptyAddressFinalBalance = web3.utils.fromWei((await web3.eth.getBalance(emptyAddress)), 'ether')
+                assert.equal(registryInitialWithForcedEther,10)
+                assert.equal(registryFinalBalance,0)
+                assert.equal(emptyAddressFinalBalance,10)
+            })
+
+        })
+    })
+}
+
+export default registryTests

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -1,20 +1,14 @@
-import assertRevert from './helpers/assertRevert'
 const RegistryMock = artifacts.require('RegistryMock')
 const MockToken = artifacts.require("MockToken")
 const ForceEther = artifacts.require("ForceEther")
 const RegistryTokenMock = artifacts.require('RegistryTokenMock')
 
-const BN = web3.utils.toBN;
+import assertRevert from './helpers/assertRevert'
 const writeAttributeFor = require('./helpers/writeAttributeFor.js')
 const bytes32 = require('./helpers/bytes32.js')
 
 contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
     const prop1 = web3.utils.sha3("foo")
-    const IS_BLACKLISTED = bytes32('isBlacklisted');
-    const IS_REGISTERED_CONTRACT = bytes32('isRegisteredContract');
-    const IS_DEPOSIT_ADDRESS = bytes32('isDepositAddress');
-    const HAS_PASSED_KYC_AML = bytes32("hasPassedKYC/AML");
-    const CAN_BURN = bytes32("canBurn");
     const prop2 = bytes32("bar")
     const notes = bytes32("blarg")
     
@@ -108,127 +102,6 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
             await this.registry.setAttribute(oneHundred, canWriteProp1, 3, notes, { from: owner })
             await assertRevert(this.registry.setAttribute(anotherAccount, prop2, 3, notes, { from: oneHundred }))
             await assertRevert(this.registry.setAttributeValue(anotherAccount, prop2, 3, { from: oneHundred }))
-        })
-    })
-
-    describe('requireCanTransfer and requireCanTransferFrom', async function() {
-        it('return _to and false when nothing set', async function() {
-            const result = await this.registry.requireCanTransfer(oneHundred, anotherAccount);
-            assert.equal(result[0], anotherAccount);
-            assert.equal(result[1], false);
-            const resultFrom = await this.registry.requireCanTransferFrom(owner, oneHundred, anotherAccount);
-            assert.equal(resultFrom[0], anotherAccount);
-            assert.equal(resultFrom[1], false);
-        });
-        it('revert when _from is blacklisted', async function() {
-            await this.registry.setAttributeValue(oneHundred, IS_BLACKLISTED, 1, { from: owner });
-            await assertRevert(this.registry.requireCanTransfer(oneHundred, anotherAccount));
-            await assertRevert(this.registry.requireCanTransferFrom(owner, oneHundred, anotherAccount));
-        });
-        it('revert when _to is blacklisted', async function() {
-            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
-            await assertRevert(this.registry.requireCanTransfer(oneHundred, anotherAccount));
-            await assertRevert(this.registry.requireCanTransferFrom(owner, oneHundred, anotherAccount));
-        });
-        it('revert when _sender is blacklisted', async function() {
-            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
-            await assertRevert(this.registry.requireCanTransferFrom(anotherAccount, oneHundred, owner));
-        });
-        it('handle deposit addresses', async function() {
-            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
-            const result = await this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00000'));
-            assert.equal(result[0], anotherAccount);
-            assert.equal(result[1], false);
-            const resultFrom = await this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'fffff'));
-            assert.equal(resultFrom[0], anotherAccount);
-            assert.equal(resultFrom[1], false);
-            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
-            await assertRevert(this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
-            await assertRevert(this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
-        });
-        it('return true when recipient is a registered contract', async function() {
-            await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, anotherAccount, { from: owner });
-            const result = await this.registry.requireCanTransfer(oneHundred, anotherAccount);
-            assert.equal(result[0], anotherAccount);
-            assert.equal(result[1], true);
-            const resultFrom = await this.registry.requireCanTransferFrom(owner, oneHundred, anotherAccount);
-            assert.equal(resultFrom[0], anotherAccount);
-            assert.equal(resultFrom[1], true);
-        });
-        it ('handles deposit addresses that are registered contracts', async function() {
-            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
-            await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, anotherAccount, { from: owner });
-            const resultContract = await this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00000'));
-            assert.equal(resultContract[0], anotherAccount);
-            assert.equal(resultContract[1], true);
-            const resultFromContract = await this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'fffff'));
-            assert.equal(resultFromContract[0], anotherAccount);
-            assert.equal(resultFromContract[1], true);
-            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
-            await assertRevert(this.registry.requireCanTransfer(oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
-            await assertRevert(this.registry.requireCanTransferFrom(oneHundred, oneHundred, web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + 'eeeee')));
-        });
-    })
-
-    describe('requireCanMint', async function() {
-        it('reverts without KYCAML flag', async function() {
-            assertRevert(this.registry.requireCanMint(owner));
-            assertRevert(this.registry.requireCanMint(oneHundred));
-            assertRevert(this.registry.requireCanMint(anotherAccount));
-        })
-        it('reverts for blacklisted recipient', async function() {
-            await this.registry.setAttributeValue(anotherAccount, HAS_PASSED_KYC_AML, 1, { from: owner });
-            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
-            assertRevert(this.registry.requireCanMint(anotherAccount));
-        })
-        it('returns false for whitelisted accounts', async function() {
-            await this.registry.setAttributeValue(anotherAccount, HAS_PASSED_KYC_AML, 1, { from: owner });
-            const result = await this.registry.requireCanMint(anotherAccount);
-            assert.equal(result[0], anotherAccount);
-            assert.equal(result[1], false);
-        })
-        it('returns deposit address', async function() {
-            const depositAddress = web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00055');
-            await this.registry.setAttributeValue(depositAddress, HAS_PASSED_KYC_AML, 1, { from: owner });
-            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
-            const result = await this.registry.requireCanMint(depositAddress);
-            assert.equal(result[0], anotherAccount);
-            assert.equal(result[1], false);
-        })
-        it('returns true for registered', async function() {
-            await this.registry.setAttributeValue(anotherAccount, HAS_PASSED_KYC_AML, 1, { from: owner });
-            await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, 1, { from: owner });
-            const result = await this.registry.requireCanMint(anotherAccount);
-            assert.equal(result[0], anotherAccount);
-            assert.equal(result[1], true);
-        })
-        it('handles registered deposit addresses', async function() {
-            const depositAddress = web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00055');
-            await this.registry.setAttributeValue(depositAddress, HAS_PASSED_KYC_AML, 1, { from: owner });
-            await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, 1, { from: owner });
-            await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
-            const result = await this.registry.requireCanMint(depositAddress);
-            assert.equal(result[0], anotherAccount);
-            assert.equal(result[1], true);
-        })
-    })
-
-    describe('requireCanBurn', async function() {
-        it('reverts without CAN_BURN flag', async function() {
-            assertRevert(this.registry.requireCanBurn(owner));
-            assertRevert(this.registry.requireCanBurn(oneHundred));
-            assertRevert(this.registry.requireCanBurn(anotherAccount));
-        })
-        it('works with CAN_BURN flag', async function () {
-            await this.registry.setAttributeValue(anotherAccount, CAN_BURN, 1, { from: owner });
-            await this.registry.requireCanBurn(anotherAccount);
-            assertRevert(this.registry.requireCanBurn(owner));
-        })
-        it('reverts for blacklisted accounts', async function() {
-            await this.registry.setAttributeValue(anotherAccount, CAN_BURN, 1, { from: owner });
-            await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
-            assertRevert(this.registry.requireCanBurn(anotherAccount));
-            assertRevert(this.registry.requireCanBurn(owner));
         })
     })
 

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -1,17 +1,8 @@
+import registryTests from './Registry'
 const RegistryMock = artifacts.require('RegistryMock')
-const MockToken = artifacts.require("MockToken")
-const ForceEther = artifacts.require("ForceEther")
 const RegistryTokenMock = artifacts.require('RegistryTokenMock')
 
-import assertRevert from './helpers/assertRevert'
-const writeAttributeFor = require('./helpers/writeAttributeFor.js')
-const bytes32 = require('./helpers/bytes32.js')
-
-contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
-    const prop1 = web3.utils.sha3("foo")
-    const prop2 = bytes32("bar")
-    const notes = bytes32("blarg")
-    
+contract ('Registry', function ([_, owner, oneHundred, anotherAccount]) {
     beforeEach(async function () {
         this.registry = await RegistryMock.new({ from: owner })
         await this.registry.initialize({ from: owner })
@@ -20,122 +11,6 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
         await this.registry.setClone(this.registryToken.address);
     })
 
-    describe('ownership functions', async function(){
-        it('cannot be reinitialized', async function () {
-            await assertRevert(this.registry.initialize({ from: owner }))
-        })
-        it('can transfer ownership', async function () {
-            await this.registry.transferOwnership(anotherAccount,{ from: owner })
-            assert.equal(await this.registry.pendingOwner(),anotherAccount)
-        })
-        it('non owner cannot transfer ownership', async function () {
-            await assertRevert(this.registry.transferOwnership(anotherAccount,{ from: anotherAccount }))
-        })
-        it('can claim ownership', async function () {
-            await this.registry.transferOwnership(anotherAccount,{ from: owner })
-            await this.registry.claimOwnership({ from: anotherAccount })
-            assert.equal(await this.registry.owner(),anotherAccount)
-        })
-        it('only pending owner can claim ownership', async function () {
-            await this.registry.transferOwnership(anotherAccount,{ from: owner })
-            await assertRevert(this.registry.claimOwnership({ from: oneHundred }))
-        })
-    })
-    describe('read/write', function () {
-        it('works for owner', async function () {
-            const { receipt } = await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: owner })
-            const attr = await this.registry.getAttribute(anotherAccount, prop1)
-            assert.equal(attr[0], 3)
-            assert.equal(attr[1], notes)
-            assert.equal(attr[2], owner)
-            assert.equal(attr[3], (await web3.eth.getBlock(receipt.blockNumber)).timestamp)
-            const hasAttr = await this.registry.hasAttribute(anotherAccount, prop1)
-            assert.equal(hasAttr, true)
-            const value = await this.registry.getAttributeValue(anotherAccount, prop1)
-            assert.equal(Number(value),3)
-            const adminAddress = await this.registry.getAttributeAdminAddr(anotherAccount, prop1)
-            assert.equal(adminAddress, owner)
-            const timestamp = await this.registry.getAttributeTimestamp(anotherAccount, prop1)
-            assert.equal(timestamp, (await web3.eth.getBlock(receipt.blockNumber)).timestamp)
-        })
 
-        it('sets only desired attribute', async function () {
-            await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: owner })
-            const attr = await this.registry.getAttribute(anotherAccount, prop2)
-            assert.equal(attr[0], 0)
-            assert.equal(attr[1], '0x0000000000000000000000000000000000000000000000000000000000000000')
-            assert.equal(attr[2], 0)
-            const hasAttr = await this.registry.hasAttribute(anotherAccount, prop2)
-            assert.equal(hasAttr, false)
-        })
-
-        it('emits an event', async function () {
-            const { logs } = await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: owner })
-
-            assert.equal(logs.length, 1)
-            assert.equal(logs[0].event, 'SetAttribute')
-            assert.equal(logs[0].args.who, anotherAccount)
-            assert.equal(logs[0].args.attribute, prop1)
-            assert.equal(logs[0].args.value, 3)
-            assert.equal(logs[0].args.notes, notes)
-            assert.equal(logs[0].args.adminAddr, owner)
-        })
-
-        it('cannot be called by random non-owner', async function () {
-            await assertRevert(this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: oneHundred }))
-        })
-
-        it('owner can let others write', async function () {
-            const canWriteProp1 = writeAttributeFor(prop1);
-            await this.registry.setAttribute(oneHundred, canWriteProp1, 3, notes, { from: owner })
-            await this.registry.setAttribute(anotherAccount, prop1, 3, notes, { from: oneHundred })
-        })
-
-        it('owner can let others write attribute value', async function () {
-            const canWriteProp1 = writeAttributeFor(prop1);
-            await this.registry.setAttributeValue(oneHundred, canWriteProp1, 3, { from: owner })
-            await this.registry.setAttributeValue(anotherAccount, prop1, 3, { from: oneHundred })
-        })
-
-        it('others can only write what they are allowed to', async function () {
-            const canWriteProp1 = writeAttributeFor(prop1);
-            await this.registry.setAttribute(oneHundred, canWriteProp1, 3, notes, { from: owner })
-            await assertRevert(this.registry.setAttribute(anotherAccount, prop2, 3, notes, { from: oneHundred }))
-            await assertRevert(this.registry.setAttributeValue(anotherAccount, prop2, 3, { from: oneHundred }))
-        })
-    })
-
-    describe('no ether and no tokens', function () {
-        beforeEach(async function () {
-            this.token = await MockToken.new( this.registry.address, 100, { from: owner })
-        })
-
-        it ('owner can transfer out token in the contract address ',async function(){
-            await this.registry.reclaimToken(this.token.address, owner, { from: owner })
-        })
-
-        it('cannot transfer ether to contract address',async function(){
-            await assertRevert(this.registry.sendTransaction({ 
-                value: 33, 
-                from: owner, 
-                gas: 300000 
-             }));         
-        })
-
-        it ('owner can transfer out ether in the contract address',async function(){
-            const emptyAddress = "0x5fef93e79a73b28a9113a618aabf84f2956eb3ba"
-            const emptyAddressBalance = web3.utils.fromWei((await web3.eth.getBalance(emptyAddress)), 'ether')
-
-            const forceEther = await ForceEther.new({ from: owner, value: "10000000000000000000" })
-            await forceEther.destroyAndSend(this.registry.address, { from: owner })
-            const registryInitialWithForcedEther = web3.utils.fromWei((await web3.eth.getBalance(this.registry.address)), 'ether')
-            await this.registry.reclaimEther(emptyAddress, { from: owner })
-            const registryFinalBalance = web3.utils.fromWei((await web3.eth.getBalance(this.registry.address)), 'ether')
-            const emptyAddressFinalBalance = web3.utils.fromWei((await web3.eth.getBalance(emptyAddress)), 'ether')
-            assert.equal(registryInitialWithForcedEther,10)
-            assert.equal(registryFinalBalance,0)
-            assert.equal(emptyAddressFinalBalance,10)
-        })
-
-    })
+    registryTests([owner, oneHundred, anotherAccount])
 })

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -111,25 +111,6 @@ contract('Registry', function ([_, owner, oneHundred, anotherAccount]) {
         })
     })
 
-    describe('sync', function() {
-        beforeEach(async function() {
-            await this.registry.setAttributeValue(oneHundred, prop1, 3, { from: owner });
-        })
-        it('writes sync', async function() {
-            assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
-        })
-        it('syncs prior writes', async function() {
-            let token2 = await RegistryTokenMock.new({ from: owner });
-            await token2.setRegistry(this.registry.address, { from: owner });
-            await this.registry.setClone(token2.address);
-            assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
-            assert.equal(0, await token2.getAttributeValue(oneHundred, prop1));
-
-            await this.registry.syncAttributes([oneHundred], [prop1]);
-            assert.equal(3, await token2.getAttributeValue(oneHundred, prop1));
-        })
-    })
-
     describe('requireCanTransfer and requireCanTransferFrom', async function() {
         it('return _to and false when nothing set', async function() {
             const result = await this.registry.requireCanTransfer(oneHundred, anotherAccount);

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -1,5 +1,5 @@
 import assertRevert from './helpers/assertRevert'
-const RegistryMock = artifacts.require('RegistryMock')
+const RegistryMock = artifacts.require('ProvisionalRegistryMock')
 const MockToken = artifacts.require("MockToken")
 const ForceEther = artifacts.require("ForceEther")
 const RegistryTokenMock = artifacts.require('RegistryTokenMock')

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -1,5 +1,5 @@
 import assertRevert from './helpers/assertRevert'
-const RegistryMock = artifacts.require('ProvisionalRegistryMock')
+const RegistryMock = artifacts.require('RegistryMock')
 const MockToken = artifacts.require("MockToken")
 const ForceEther = artifacts.require("ForceEther")
 const RegistryTokenMock = artifacts.require('RegistryTokenMock')


### PR DESCRIPTION

#### Changes
This creates a write-through registry that writes its values to its RegistryTokens.
It also creates a ProvisionalRegistry contract that retains methods that will only be needed during the upgrade.
Reviewers @terryli0095