### PR TITLE
Attribute Subscription

### DIFF
--- a/contracts/ProvisionalRegistry.sol
+++ b/contracts/ProvisionalRegistry.sol
@@ -3,14 +3,11 @@ pragma solidity ^0.4.23;
 import "./Registry.sol";
 
 contract ProvisionalRegistry is Registry {
-    function syncAttributes(address[] _addresses, bytes32[] _attributes) external {
-        RegistryClone replica = clone();
-        for (uint i = 0; i < _attributes.length; i++) {
-            address who = _addresses[i];
-            bytes32 attribute = _attributes[i];
-            replica.syncAttributeValue(who, attribute, attributes[who][attribute].value);
-        }
-    }
+    bytes32 constant IS_BLACKLISTED = "isBlacklisted";
+    bytes32 constant IS_DEPOSIT_ADDRESS = "isDepositAddress";
+    bytes32 constant IS_REGISTERED_CONTRACT = "isRegisteredContract";
+    bytes32 constant HAS_PASSED_KYC_AML = "hasPassedKYC/AML";
+    bytes32 constant CAN_BURN = "canBurn";
 
     function requireCanTransfer(address _from, address _to) public view returns (address, bool) {
         require (attributes[_from][IS_BLACKLISTED].value == 0, "blacklisted");

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -112,22 +112,10 @@ contract Registry {
         return attributes[_who][_attribute].timestamp;
     }
 
-    function syncAttributes(bytes32[] _attributes, address[] _addresses) external {
-        for (uint i = 0; i < _attributes.length; i++) {
-            address who = _addresses[i];
-            bytes32 attribute = _attributes[i];
-            RegistryClone[] storage targets = subscribers[attribute];
-            uint256 index = targets.length;
-            while (index --> 0) {
-                targets[index].syncAttributeValue(who, attribute, attributes[who][attribute].value);
-            }
-        }
-    }
-
-    function syncAttribute(bytes32 _attribute, address[] _addresses) external {
+    function syncAttribute(bytes32 _attribute, uint256 _startIndex, address[] _addresses) external {
         RegistryClone[] storage targets = subscribers[_attribute];
         uint256 index = targets.length;
-        while (index --> 0) {
+        while (index --> _startIndex) {
             RegistryClone target = targets[index];
             for (uint256 i = _addresses.length; i --> 0; ) {
                 address who = _addresses[i];

--- a/contracts/mocks/RegistryMock.sol
+++ b/contracts/mocks/RegistryMock.sol
@@ -4,7 +4,6 @@ import "../ProvisionalRegistry.sol";
 
 contract RegistryMock is Registry {
 
-    RegistryClone _clone;
 
     /**
     * @dev sets the original `owner` of the contract to the sender
@@ -19,14 +18,6 @@ contract RegistryMock is Registry {
         require(!initialized, "already initialized");
         owner = msg.sender;
         initialized = true;
-    }
-
-    function setClone(RegistryClone __clone) public {
-        _clone = __clone;
-    }
-
-    function clone() internal view returns (RegistryClone) {
-        return _clone;
     }
 }
 

--- a/test/ProvisionalRegistry.test.js
+++ b/test/ProvisionalRegistry.test.js
@@ -1,6 +1,5 @@
 import registryTests from './Registry'
 const ProvisionalRegistryMock = artifacts.require('ProvisionalRegistryMock')
-const RegistryTokenMock = artifacts.require('RegistryTokenMock')
 
 import assertRevert from './helpers/assertRevert'
 const bytes32 = require('./helpers/bytes32.js')
@@ -17,47 +16,8 @@ contract('ProvisionalRegistry', function ([_, owner, oneHundred, anotherAccount]
     beforeEach(async function () {
         this.registry = await ProvisionalRegistryMock.new({ from: owner })
         await this.registry.initialize({ from: owner })
-        this.registryToken = await RegistryTokenMock.new({ from: owner })
-        await this.registryToken.setRegistry(this.registry.address, { from: owner })
-        await this.registry.setClone(this.registryToken.address);
     })
     registryTests([owner, oneHundred, anotherAccount])
-
-    describe('sync', function() {
-        beforeEach(async function() {
-            await this.registry.setAttributeValue(oneHundred, prop1, 3, { from: owner });
-        })
-        it('writes sync', async function() {
-            assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
-        })
-        it('syncs prior writes', async function() {
-            let token2 = await RegistryTokenMock.new({ from: owner });
-            await token2.setRegistry(this.registry.address, { from: owner });
-            await this.registry.setClone(token2.address);
-            assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
-            assert.equal(0, await token2.getAttributeValue(oneHundred, prop1));
-
-            await this.registry.syncAttributes([oneHundred], [prop1]);
-            assert.equal(3, await token2.getAttributeValue(oneHundred, prop1));
-        })
-        it('syncs multiple prior writes', async function() {
-
-            await this.registry.setAttributeValue(oneHundred, prop2, 4, { from: owner});
-            await this.registry.setAttributeValue(anotherAccount, prop2, 5, { from: owner});
-            await this.registry.setAttributeValue(owner, CAN_BURN, 6, { from: owner});
-            let token2 = await RegistryTokenMock.new({ from: owner });
-            await token2.setRegistry(this.registry.address, { from: owner });
-            await this.registry.setClone(token2.address);
-            assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
-            assert.equal(0, await token2.getAttributeValue(oneHundred, prop1));
-
-            await this.registry.syncAttributes([oneHundred, oneHundred, anotherAccount, owner], [prop1, prop2, prop2, CAN_BURN]);
-            assert.equal(3, await token2.getAttributeValue(oneHundred, prop1));
-            assert.equal(4, await token2.getAttributeValue(oneHundred, prop2));
-            assert.equal(5, await token2.getAttributeValue(anotherAccount, prop2));
-            assert.equal(6, await token2.getAttributeValue(owner, CAN_BURN));
-        })
-    })
 
     describe('requireCanTransfer and requireCanTransferFrom', async function() {
         it('return _to and false when nothing set', async function() {

--- a/test/Registry.js
+++ b/test/Registry.js
@@ -1,15 +1,18 @@
+const RegistryTokenMock = artifacts.require('RegistryTokenMock')
 const MockToken = artifacts.require("MockToken")
 const ForceEther = artifacts.require("ForceEther")
 
 import assertRevert from './helpers/assertRevert'
 const writeAttributeFor = require('./helpers/writeAttributeFor.js')
 const bytes32 = require('./helpers/bytes32.js')
+const BN = web3.utils.toBN;
 
 function registryTests([owner, oneHundred, anotherAccount]) {
     describe('--Registry Tests--', function () {
         const prop1 = web3.utils.sha3("foo")
         const prop2 = bytes32("bar")
         const notes = bytes32("blarg")
+        const CAN_BURN = bytes32("canBurn");
         
         describe('ownership functions', function(){
             it('cannot be reinitialized', async function () {
@@ -129,6 +132,75 @@ function registryTests([owner, oneHundred, anotherAccount]) {
             })
 
         })
+
+        describe('sync', function() {
+            beforeEach(async function() {
+                this.registryToken = await RegistryTokenMock.new({ from: owner })
+                await this.registryToken.setRegistry(this.registry.address, { from: owner })
+                await this.registry.subscribe(prop1, this.registryToken.address, { from: owner });
+                await this.registry.setAttributeValue(oneHundred, prop1, 3, { from: owner });
+            })
+            it('writes sync', async function() {
+                assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
+            })
+            it('subscription emits event', async function() {
+                const { logs } = await this.registry.subscribe(prop2, this.registryToken.address, { from: owner });
+                assert.equal(logs.length, 1);
+                assert.equal(logs[0].args.attribute, prop2);
+                assert.equal(logs[0].args.subscriber, this.registryToken.address);
+                assert(BN(1).eq(await this.registry.subscriberCount(prop2)), 'should have 1 subscriber');
+            })
+            it('unsubscription emits event', async function() {
+                const { logs } = await this.registry.unsubscribe(prop1, 0, { from: owner });
+                assert.equal(logs.length, 1);
+                assert.equal(logs[0].args.attribute, prop1);
+                assert.equal(logs[0].args.subscriber, this.registryToken.address);
+            })
+            it('can unsubscribe', async function() {
+                assert(BN(1).eq(await this.registry.subscriberCount(prop1)), 'should have 1 subscriber');
+                await this.registry.unsubscribe(prop1, 0, { from: owner });
+                assert(BN(0).eq(await this.registry.subscriberCount(prop1)), 'should have 0 subscribers');
+            })
+            it('syncs prior writes', async function() {
+                let token2 = await RegistryTokenMock.new({ from: owner });
+                await token2.setRegistry(this.registry.address, { from: owner });
+                await this.registry.subscribe(prop1, token2.address, {from: owner});
+                assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
+                assert.equal(0, await token2.getAttributeValue(oneHundred, prop1));
+
+                await this.registry.syncAttributes([prop1], [oneHundred]);
+                assert.equal(3, await token2.getAttributeValue(oneHundred, prop1));
+            })
+            it('syncs prior attribute', async function() {
+                let token2 = await RegistryTokenMock.new({ from: owner });
+                await token2.setRegistry(this.registry.address, { from: owner });
+                await this.registry.subscribe(prop1, token2.address, {from: owner});
+                assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
+                assert.equal(0, await token2.getAttributeValue(oneHundred, prop1));
+                await this.registry.syncAttributes([prop1], [oneHundred]);
+                assert.equal(3, await token2.getAttributeValue(oneHundred, prop1));
+            })
+            it('syncs multiple prior writes', async function() {
+
+                await this.registry.setAttributeValue(oneHundred, prop2, 4, { from: owner});
+                await this.registry.setAttributeValue(anotherAccount, prop2, 5, { from: owner});
+                await this.registry.setAttributeValue(owner, CAN_BURN, 6, { from: owner});
+                let token2 = await RegistryTokenMock.new({ from: owner });
+                await token2.setRegistry(this.registry.address, { from: owner });
+                await this.registry.subscribe(prop1, token2.address, { from: owner });
+                await this.registry.subscribe(prop2, token2.address, { from: owner });
+                await this.registry.subscribe(CAN_BURN, token2.address, { from: owner });
+                assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1), { from: owner });
+                assert.equal(0, await token2.getAttributeValue(oneHundred, prop1));
+
+                await this.registry.syncAttributes([prop1, prop2, prop2, CAN_BURN], [oneHundred, oneHundred, anotherAccount, owner]);
+                assert.equal(3, await token2.getAttributeValue(oneHundred, prop1));
+                assert.equal(4, await token2.getAttributeValue(oneHundred, prop2));
+                assert.equal(5, await token2.getAttributeValue(anotherAccount, prop2));
+                assert.equal(6, await token2.getAttributeValue(owner, CAN_BURN));
+            })
+        })
+
     })
 }
 

--- a/test/Registry.js
+++ b/test/Registry.js
@@ -168,7 +168,7 @@ function registryTests([owner, oneHundred, anotherAccount]) {
                 assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
                 assert.equal(0, await token2.getAttributeValue(oneHundred, prop1));
 
-                await this.registry.syncAttributes([prop1], [oneHundred]);
+                await this.registry.syncAttribute(prop1, 0, [oneHundred]);
                 assert.equal(3, await token2.getAttributeValue(oneHundred, prop1));
             })
             it('syncs prior attribute', async function() {
@@ -177,27 +177,25 @@ function registryTests([owner, oneHundred, anotherAccount]) {
                 await this.registry.subscribe(prop1, token2.address, {from: owner});
                 assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1));
                 assert.equal(0, await token2.getAttributeValue(oneHundred, prop1));
-                await this.registry.syncAttributes([prop1], [oneHundred]);
+                await this.registry.syncAttribute(prop1, 0, [oneHundred]);
                 assert.equal(3, await token2.getAttributeValue(oneHundred, prop1));
             })
             it('syncs multiple prior writes', async function() {
+                await this.registry.setAttributeValue(oneHundred, prop1, 3, { from: owner});
+                await this.registry.setAttributeValue(anotherAccount, prop1, 5, { from: owner});
+                await this.registry.setAttributeValue(owner, prop1, 6, { from: owner});
 
-                await this.registry.setAttributeValue(oneHundred, prop2, 4, { from: owner});
-                await this.registry.setAttributeValue(anotherAccount, prop2, 5, { from: owner});
-                await this.registry.setAttributeValue(owner, CAN_BURN, 6, { from: owner});
                 let token2 = await RegistryTokenMock.new({ from: owner });
                 await token2.setRegistry(this.registry.address, { from: owner });
                 await this.registry.subscribe(prop1, token2.address, { from: owner });
-                await this.registry.subscribe(prop2, token2.address, { from: owner });
-                await this.registry.subscribe(CAN_BURN, token2.address, { from: owner });
+                await this.registry.syncAttribute(prop1, 2, [oneHundred, anotherAccount, owner]);
                 assert.equal(3, await this.registryToken.getAttributeValue(oneHundred, prop1), { from: owner });
                 assert.equal(0, await token2.getAttributeValue(oneHundred, prop1));
 
-                await this.registry.syncAttributes([prop1, prop2, prop2, CAN_BURN], [oneHundred, oneHundred, anotherAccount, owner]);
+                await this.registry.syncAttribute(prop1, 1, [oneHundred, anotherAccount, owner]);
                 assert.equal(3, await token2.getAttributeValue(oneHundred, prop1));
-                assert.equal(4, await token2.getAttributeValue(oneHundred, prop2));
-                assert.equal(5, await token2.getAttributeValue(anotherAccount, prop2));
-                assert.equal(6, await token2.getAttributeValue(owner, CAN_BURN));
+                assert.equal(5, await token2.getAttributeValue(anotherAccount, prop1));
+                assert.equal(6, await token2.getAttributeValue(owner, prop1));
             })
         })
 

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -6,11 +6,7 @@ contract ('Registry', function ([_, owner, oneHundred, anotherAccount]) {
     beforeEach(async function () {
         this.registry = await RegistryMock.new({ from: owner })
         await this.registry.initialize({ from: owner })
-        this.registryToken = await RegistryTokenMock.new({ from: owner })
-        await this.registryToken.setRegistry(this.registry.address, { from: owner })
-        await this.registry.setClone(this.registryToken.address);
     })
-
 
     registryTests([owner, oneHundred, anotherAccount])
 })


### PR DESCRIPTION

#### Changes
This modifies the write-through registry such that the owner can subscribe targets to attribute changes.
Compared to the previous implementation, this one can support multiple targets, attributes that do not sync anywhere, and attributes that sync to only a subset of the targets.
Reviewers @terryli0095