### PR TITLE
rm KYC/AML flag from requireCanMint

### DIFF
--- a/contracts/ProvisionalRegistry.sol
+++ b/contracts/ProvisionalRegistry.sol
@@ -6,7 +6,6 @@ contract ProvisionalRegistry is Registry {
     bytes32 constant IS_BLACKLISTED = "isBlacklisted";
     bytes32 constant IS_DEPOSIT_ADDRESS = "isDepositAddress";
     bytes32 constant IS_REGISTERED_CONTRACT = "isRegisteredContract";
-    bytes32 constant HAS_PASSED_KYC_AML = "hasPassedKYC/AML";
     bytes32 constant CAN_BURN = "canBurn";
 
     function requireCanTransfer(address _from, address _to) public view returns (address, bool) {
@@ -25,7 +24,6 @@ contract ProvisionalRegistry is Registry {
     }
 
     function requireCanMint(address _to) public view returns (address, bool) {
-        require (attributes[_to][HAS_PASSED_KYC_AML].value != 0);
         require (attributes[_to][IS_BLACKLISTED].value == 0, "blacklisted");
         uint256 depositAddressValue = attributes[address(uint256(_to) >> 20)][IS_DEPOSIT_ADDRESS].value;
         if (depositAddressValue != 0) {

--- a/test/ProvisionalRegistry.test.js
+++ b/test/ProvisionalRegistry.test.js
@@ -9,7 +9,6 @@ contract('ProvisionalRegistry', function ([_, owner, oneHundred, anotherAccount]
     const IS_BLACKLISTED = bytes32('isBlacklisted');
     const IS_REGISTERED_CONTRACT = bytes32('isRegisteredContract');
     const IS_DEPOSIT_ADDRESS = bytes32('isDepositAddress');
-    const HAS_PASSED_KYC_AML = bytes32("hasPassedKYC/AML");
     const CAN_BURN = bytes32("canBurn");
     const prop2 = bytes32("bar")
     
@@ -79,32 +78,23 @@ contract('ProvisionalRegistry', function ([_, owner, oneHundred, anotherAccount]
     })
 
     describe('requireCanMint', async function() {
-        it('reverts without KYCAML flag', async function() {
-            await assertRevert(this.registry.requireCanMint(owner));
-            await assertRevert(this.registry.requireCanMint(oneHundred));
-            await assertRevert(this.registry.requireCanMint(anotherAccount));
-        })
         it('reverts for blacklisted recipient', async function() {
-            await this.registry.setAttributeValue(anotherAccount, HAS_PASSED_KYC_AML, 1, { from: owner });
             await this.registry.setAttributeValue(anotherAccount, IS_BLACKLISTED, 1, { from: owner });
             await assertRevert(this.registry.requireCanMint(anotherAccount));
         })
         it('returns false for whitelisted accounts', async function() {
-            await this.registry.setAttributeValue(anotherAccount, HAS_PASSED_KYC_AML, 1, { from: owner });
             const result = await this.registry.requireCanMint(anotherAccount);
             assert.equal(result[0], anotherAccount);
             assert.equal(result[1], false);
         })
         it('returns deposit address', async function() {
             const depositAddress = web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00055');
-            await this.registry.setAttributeValue(depositAddress, HAS_PASSED_KYC_AML, 1, { from: owner });
             await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
             const result = await this.registry.requireCanMint(depositAddress);
             assert.equal(result[0], anotherAccount);
             assert.equal(result[1], false);
         })
         it('returns true for registered', async function() {
-            await this.registry.setAttributeValue(anotherAccount, HAS_PASSED_KYC_AML, 1, { from: owner });
             await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, 1, { from: owner });
             const result = await this.registry.requireCanMint(anotherAccount);
             assert.equal(result[0], anotherAccount);
@@ -112,7 +102,6 @@ contract('ProvisionalRegistry', function ([_, owner, oneHundred, anotherAccount]
         })
         it('handles registered deposit addresses', async function() {
             const depositAddress = web3.utils.toChecksumAddress(anotherAccount.slice(0, -5) + '00055');
-            await this.registry.setAttributeValue(depositAddress, HAS_PASSED_KYC_AML, 1, { from: owner });
             await this.registry.setAttributeValue(anotherAccount, IS_REGISTERED_CONTRACT, 1, { from: owner });
             await this.registry.setAttributeValue(web3.utils.toChecksumAddress('0x00000' + anotherAccount.slice(2, -5)), IS_DEPOSIT_ADDRESS, anotherAccount, { from: owner });
             const result = await this.registry.requireCanMint(depositAddress);


### PR DESCRIPTION

#### Changes
This removes the KYC/AML flag check from minting.
This is our most-common flag set in the registry.
Reviewers @terryli0095